### PR TITLE
OpenEventLog() takes two string pointers

### DIFF
--- a/advapi32.go
+++ b/advapi32.go
@@ -189,10 +189,10 @@ func RegEnumKeyEx(hKey HKEY, index uint32) string {
 	return syscall.UTF16ToString(buf)
 }
 
-func OpenEventLog(servername, sourcename *uint16) HANDLE {
+func OpenEventLog(servername string, sourcename string) HANDLE {
 	ret, _, _ := procOpenEventLog.Call(
-		uintptr(unsafe.Pointer(servername)),
-		uintptr(unsafe.Pointer(sourcename)))
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(servername))),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(sourcename))))
 
 	return HANDLE(ret)
 }


### PR DESCRIPTION
Hello,

[MSDN specifications](http://msdn.microsoft.com/en-us/library/windows/desktop/aa363672%28v=vs.85%29.aspx) defines OpenEventLog() arguments as strings:

``` C
HANDLE OpenEventLog(
  _In_  LPCTSTR lpUNCServerName,
  _In_  LPCTSTR lpSourceName
);
```
