### PR TITLE
Fix build on mingw

### DIFF
--- a/user32.go
+++ b/user32.go
@@ -5,7 +5,8 @@
 package w32
 
 import (
-	// #include <WTypes.h>
+	// #include <wtypes.h>
+	// #include <winable.h>
 	"C"
 	"fmt"
 	"syscall"


### PR DESCRIPTION
```
WORK=C:\Users\mattn\AppData\Local\Temp\go-build906783563
mkdir -p $WORK\github.com\AllenDang\w32\_obj\
mkdir -p $WORK\github.com\AllenDang\
cd c:\dev\go\src\github.com\AllenDang\w32
"c:\\go\\pkg\\tool\\windows_386\\cgo.exe" -objdir "C:\\Users\\mattn\\AppData\\Local\\Temp\\go-build906783563\\github.com\\AllenDang\\w32\\_obj\\" -- -I "C:\\Users\\mattn\\AppData\\Local\\Temp\\go-build906783563\\github.com\\AllenDang\\w32\\_obj\\" user32.go
# github.com/AllenDang/w32
37: error: 'INPUT' undeclared (first use in this function)
```
