### PR TITLE
Added support for GetSystemTime() and SetSystemTime()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Benny Siegert <bsiegert@gmail.com>
 Bruno Bigras <bigras.bruno@gmail.com>
 Gerald Rosenberg <gerald.rosenberg@gmail.com>
 Michael Henke
+Paul Maddox <paul.maddox@gmail.com>

--- a/kernel32.go
+++ b/kernel32.go
@@ -41,6 +41,8 @@ var (
 	procSetConsoleTextAttribute    = modkernel32.NewProc("SetConsoleTextAttribute")
 	procGetDiskFreeSpaceEx         = modkernel32.NewProc("GetDiskFreeSpaceExW")
 	procGetProcessTimes            = modkernel32.NewProc("GetProcessTimes")
+	procSetSystemTime              = modkernel32.NewProc("SetSystemTime")
+	procGetSystemTime              = modkernel32.NewProc("GetSystemTime")
 )
 
 func GetModuleHandle(modulename string) HINSTANCE {
@@ -295,4 +297,17 @@ func GetDiskFreeSpaceEx(dirName string) (r bool,
 		uintptr(unsafe.Pointer(&totalNumberOfFreeBytes)))
 	return ret != 0,
 		freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes
+}
+
+func GetSystemTime() *SYSTEMTIME {
+	var time SYSTEMTIME
+	procGetSystemTime.Call(
+		uintptr(unsafe.Pointer(&time)))
+	return &time
+}
+
+func SetSystemTime(time *SYSTEMTIME) bool {
+	ret, _, _ := procSetSystemTime.Call(
+		uintptr(unsafe.Pointer(time)))
+	return ret != 0
 }

--- a/typedef.go
+++ b/typedef.go
@@ -887,3 +887,15 @@ type HardwareInput struct {
 	typ uint32
 	hi  HARDWAREINPUT
 }
+
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms724950(v=vs.85).aspx
+type SYSTEMTIME struct {
+	Year         uint16
+	Month        uint16
+	DayOfWeek    uint16
+	Day          uint16
+	Hour         uint16
+	Minute       uint16
+	Second       uint16
+	Milliseconds uint16
+}


### PR DESCRIPTION
[GetSystemTime() documentation](http://msdn.microsoft.com/en-gb/library/windows/desktop/ms724390%28v=vs.85%29.aspx)
[SetSystemTime() documentation](http://msdn.microsoft.com/en-gb/library/windows/desktop/ms724942%28v=vs.85%29.aspx)
[SYSTEMTIME struct documentation](http://msdn.microsoft.com/en-gb/library/windows/desktop/ms724950%28v=vs.85%29.aspx)

Tested on a Windows Server 2012 R2 machine.
