### PR TITLE
Add functions for registry

### DIFF
--- a/advapi32.go
+++ b/advapi32.go
@@ -21,6 +21,9 @@ var (
 	procRegEnumKeyEx   = modadvapi32.NewProc("RegEnumKeyExW")
 	//	procRegSetKeyValue     = modadvapi32.NewProc("RegSetKeyValueW")
 	procRegSetValueEx      = modadvapi32.NewProc("RegSetValueExW")
+	procRegDeleteKeyValue  = modadvapi32.NewProc("RegDeleteKeyValueW")
+	procRegDeleteValue     = modadvapi32.NewProc("RegDeleteValueW")
+	procRegDeleteTree      = modadvapi32.NewProc("RegDeleteTreeW")
 	procOpenEventLog       = modadvapi32.NewProc("OpenEventLogW")
 	procReadEventLog       = modadvapi32.NewProc("ReadEventLogW")
 	procCloseEventLog      = modadvapi32.NewProc("CloseEventLog")
@@ -228,6 +231,31 @@ func RegSetKeyValue(hKey HKEY, subKey string, valueName string, dwType uint32, d
 	return int(ret)
 }
 */
+
+func RegDeleteKeyValue(hKey HKEY, subKey string, valueName string) (errno int) {
+	ret, _, _ := procRegDeleteKeyValue.Call(
+		uintptr(hKey),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(subKey))),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(valueName))))
+
+	return int(ret)
+}
+
+func RegDeleteValue(hKey HKEY, valueName string) (errno int) {
+	ret, _, _ := procRegDeleteValue.Call(
+		uintptr(hKey),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(valueName))))
+
+	return int(ret)
+}
+
+func RegDeleteTree(hKey HKEY, subKey string) (errno int) {
+	ret, _, _ := procRegDeleteTree.Call(
+		uintptr(hKey),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(subKey))))
+
+	return int(ret)
+}
 
 func RegEnumKeyEx(hKey HKEY, index uint32) string {
 	var bufLen uint32 = 255


### PR DESCRIPTION
Hi, I added functions for getting, setting and deleting registry values.
Could you review this pull request?
Here is a sample code using these functions.

```
package main

import (
	"fmt"
	"github.com/AllenDang/w32"
)

func main() {
	hKey := w32.RegCreateKey(w32.HKEY_LOCAL_MACHINE, `SOFTWARE\Microsoft\Internet Explorer\Setup\8.0`)
	fmt.Printf("hKey=%v\n", hKey)
	errno := w32.RegSetUint32(hKey, "DoNotAllowIE80", 1)
	fmt.Printf("errno=%d\n", errno)
	errno = w32.RegSetString(hKey, "hello", "ほげ")
	fmt.Printf("errno=%d\n", errno)

	data, errno := w32.RegGetUint32(w32.HKEY_LOCAL_MACHINE, `SOFTWARE\Microsoft\Internet Explorer\Setup\8.0`, "DoNotAllowIE80")
	fmt.Printf("data=%d, errno=%d\n", data, errno)

	errno = w32.RegDeleteValue(hKey, "hello")
	fmt.Printf("errno=%d\n", errno)

	errno = w32.RegDeleteTree(w32.HKEY_LOCAL_MACHINE, `SOFTWARE\Microsoft\Internet Explorer\Setup\8.0`)
	fmt.Printf("errno=%d\n", errno)

	w32.RegCloseKey(hKey)
}
```

Thanks!