### PR TITLE
remove all cgo code

### DIFF
--- a/alpc.go
+++ b/alpc.go
@@ -4,11 +4,6 @@
 
 package w32
 
-// #include <stdlib.h>
-import (
-	"C"
-)
-
 import (
 	"fmt"
 	// "github.com/davecgh/go-spew/spew"
@@ -29,30 +24,30 @@ var (
 	procRtlCreateUnicodeStringFromAsciiz = modntdll.NewProc("RtlCreateUnicodeStringFromAsciiz")
 )
 
-func RtlCreateUnicodeStringFromAsciiz(s string) (us UNICODE_STRING, e error) {
+//func RtlCreateUnicodeStringFromAsciiz(s string) (us UNICODE_STRING, e error) {
+//
+//	cs := C.CString(s)
+//	defer C.free(unsafe.Pointer(cs))
+//
+//	ret, _, lastErr := procRtlCreateUnicodeStringFromAsciiz.Call(
+//		uintptr(unsafe.Pointer(&us)),
+//		uintptr(unsafe.Pointer(cs)),
+//	)
+//
+//	if ret != 1 { // ret is a BOOL ( I think )
+//		e = lastErr
+//	}
+//
+//	return
+//}
 
-	cs := C.CString(s)
-	defer C.free(unsafe.Pointer(cs))
-
-	ret, _, lastErr := procRtlCreateUnicodeStringFromAsciiz.Call(
-		uintptr(unsafe.Pointer(&us)),
-		uintptr(unsafe.Pointer(cs)),
-	)
-
-	if ret != 1 { // ret is a BOOL ( I think )
-		e = lastErr
-	}
-
-	return
-}
-
-func newUnicodeString(s string) (us UNICODE_STRING, e error) {
-	// TODO probably not the most efficient way to do this, but I couldn't
-	// work out how to manually initialize the UNICODE_STRING struct in a way
-	// that the ALPC subsystem liked.
-	us, e = RtlCreateUnicodeStringFromAsciiz(s)
-	return
-}
+//func newUnicodeString(s string) (us UNICODE_STRING, e error) {
+//	// TODO probably not the most efficient way to do this, but I couldn't
+//	// work out how to manually initialize the UNICODE_STRING struct in a way
+//	// that the ALPC subsystem liked.
+//	us, e = RtlCreateUnicodeStringFromAsciiz(s)
+//	return
+//}
 
 // (this is a macro)
 // VOID InitializeObjectAttributes(
@@ -62,31 +57,31 @@ func newUnicodeString(s string) (us UNICODE_STRING, e error) {
 //   [in]            HANDLE RootDirectory,
 //   [in, optional]  PSECURITY_DESCRIPTOR SecurityDescriptor
 // )
-func InitializeObjectAttributes(
-	name string,
-	attributes uint32,
-	rootDir HANDLE,
-	pSecurityDescriptor *SECURITY_DESCRIPTOR,
-) (oa OBJECT_ATTRIBUTES, e error) {
-
-	oa = OBJECT_ATTRIBUTES{
-		RootDirectory:      rootDir,
-		Attributes:         attributes,
-		SecurityDescriptor: pSecurityDescriptor,
-	}
-	oa.Length = uint32(unsafe.Sizeof(oa))
-
-	if len(name) > 0 {
-		us, err := newUnicodeString(name)
-		if err != nil {
-			e = err
-			return
-		}
-		oa.ObjectName = &us
-	}
-
-	return
-}
+//func InitializeObjectAttributes(
+//	name string,
+//	attributes uint32,
+//	rootDir HANDLE,
+//	pSecurityDescriptor *SECURITY_DESCRIPTOR,
+//) (oa OBJECT_ATTRIBUTES, e error) {
+//
+//	oa = OBJECT_ATTRIBUTES{
+//		RootDirectory:      rootDir,
+//		Attributes:         attributes,
+//		SecurityDescriptor: pSecurityDescriptor,
+//	}
+//	oa.Length = uint32(unsafe.Sizeof(oa))
+//
+//	if len(name) > 0 {
+//		us, err := newUnicodeString(name)
+//		if err != nil {
+//			e = err
+//			return
+//		}
+//		oa.ObjectName = &us
+//	}
+//
+//	return
+//}
 
 // NTSTATUS
 // NtAlpcCreatePort(
@@ -123,43 +118,43 @@ func NtAlpcCreatePort(pObjectAttributes *OBJECT_ATTRIBUTES, pPortAttributes *ALP
 //     __inout_opt PALPC_MESSAGE_ATTRIBUTES InMessageAttributes,
 //     __in_opt PLARGE_INTEGER Timeout
 //     );
-func NtAlpcConnectPort(
-	destPort string,
-	pClientObjAttrs *OBJECT_ATTRIBUTES,
-	pClientAlpcPortAttrs *ALPC_PORT_ATTRIBUTES,
-	flags uint32,
-	pRequiredServerSid *SID,
-	pConnMsg *AlpcShortMessage,
-	pBufLen *uint32,
-	pOutMsgAttrs *ALPC_MESSAGE_ATTRIBUTES,
-	pInMsgAttrs *ALPC_MESSAGE_ATTRIBUTES,
-	timeout *int64,
-) (hPort HANDLE, e error) {
-
-	destPortU, e := newUnicodeString(destPort)
-	if e != nil {
-		return
-	}
-
-	ret, _, _ := procNtAlpcConnectPort.Call(
-		uintptr(unsafe.Pointer(&hPort)),
-		uintptr(unsafe.Pointer(&destPortU)),
-		uintptr(unsafe.Pointer(pClientObjAttrs)),
-		uintptr(unsafe.Pointer(pClientAlpcPortAttrs)),
-		uintptr(flags),
-		uintptr(unsafe.Pointer(pRequiredServerSid)),
-		uintptr(unsafe.Pointer(pConnMsg)),
-		uintptr(unsafe.Pointer(pBufLen)),
-		uintptr(unsafe.Pointer(pOutMsgAttrs)),
-		uintptr(unsafe.Pointer(pInMsgAttrs)),
-		uintptr(unsafe.Pointer(timeout)),
-	)
-
-	if ret != ERROR_SUCCESS {
-		e = fmt.Errorf("0x%x", ret)
-	}
-	return
-}
+//func NtAlpcConnectPort(
+//	destPort string,
+//	pClientObjAttrs *OBJECT_ATTRIBUTES,
+//	pClientAlpcPortAttrs *ALPC_PORT_ATTRIBUTES,
+//	flags uint32,
+//	pRequiredServerSid *SID,
+//	pConnMsg *AlpcShortMessage,
+//	pBufLen *uint32,
+//	pOutMsgAttrs *ALPC_MESSAGE_ATTRIBUTES,
+//	pInMsgAttrs *ALPC_MESSAGE_ATTRIBUTES,
+//	timeout *int64,
+//) (hPort HANDLE, e error) {
+//
+//	destPortU, e := newUnicodeString(destPort)
+//	if e != nil {
+//		return
+//	}
+//
+//	ret, _, _ := procNtAlpcConnectPort.Call(
+//		uintptr(unsafe.Pointer(&hPort)),
+//		uintptr(unsafe.Pointer(&destPortU)),
+//		uintptr(unsafe.Pointer(pClientObjAttrs)),
+//		uintptr(unsafe.Pointer(pClientAlpcPortAttrs)),
+//		uintptr(flags),
+//		uintptr(unsafe.Pointer(pRequiredServerSid)),
+//		uintptr(unsafe.Pointer(pConnMsg)),
+//		uintptr(unsafe.Pointer(pBufLen)),
+//		uintptr(unsafe.Pointer(pOutMsgAttrs)),
+//		uintptr(unsafe.Pointer(pInMsgAttrs)),
+//		uintptr(unsafe.Pointer(timeout)),
+//	)
+//
+//	if ret != ERROR_SUCCESS {
+//		e = fmt.Errorf("0x%x", ret)
+//	}
+//	return
+//}
 
 // NTSTATUS
 // NtAlpcAcceptConnectPort(

--- a/create_process.go
+++ b/create_process.go
@@ -4,11 +4,6 @@
 
 package w32
 
-// #include <stdlib.h>
-import (
-	"C"
-)
-
 import (
 	"syscall"
 	"unsafe"

--- a/fork.go
+++ b/fork.go
@@ -5,9 +5,9 @@
 package w32
 
 // #include <stdlib.h>
-import (
-	"C"
-)
+//import (
+//	"C"
+//)
 
 // Based on C code found here https://gist.github.com/juntalis/4366916
 // Original code license:

--- a/user32.go
+++ b/user32.go
@@ -5,9 +5,6 @@
 package w32
 
 import (
-	// #include <wtypes.h>
-	// #include <winable.h>
-	"C"
 	"fmt"
 	"syscall"
 	"unsafe"
@@ -986,34 +983,6 @@ func ChangeDisplaySettingsEx(szDeviceName *uint16, devMode *DEVMODE, hwnd HWND, 
 		lParam,
 	)
 	return int32(ret)
-}
-
-func SendInput(inputs []INPUT) uint32 {
-	var validInputs []C.INPUT
-
-	for _, oneInput := range inputs {
-		input := C.INPUT{_type: C.DWORD(oneInput.Type)}
-
-		switch oneInput.Type {
-		case INPUT_MOUSE:
-			(*MouseInput)(unsafe.Pointer(&input)).mi = oneInput.Mi
-		case INPUT_KEYBOARD:
-			(*KbdInput)(unsafe.Pointer(&input)).ki = oneInput.Ki
-		case INPUT_HARDWARE:
-			(*HardwareInput)(unsafe.Pointer(&input)).hi = oneInput.Hi
-		default:
-			panic("unkown type")
-		}
-
-		validInputs = append(validInputs, input)
-	}
-
-	ret, _, _ := procSendInput.Call(
-		uintptr(len(validInputs)),
-		uintptr(unsafe.Pointer(&validInputs[0])),
-		uintptr(unsafe.Sizeof(C.INPUT{})),
-	)
-	return uint32(ret)
 }
 
 func SetWindowsHookEx(idHook int, lpfn HOOKPROC, hMod HINSTANCE, dwThreadId DWORD) HHOOK {


### PR DESCRIPTION
In my use case,I never use cgo.(I do not want install vs2017 or mingw32 to just compile my code.)
But this pr is not backward compatible.
Or should I use build flag to make cgo and no cgo happy?
try fix #72