### PR TITLE
fixed what appears to be a typo in user32

### DIFF
--- a/user32.go
+++ b/user32.go
@@ -1037,9 +1037,9 @@ func RedrawWindow(hWnd HWND, lpRect *RECT, hrgnUpdate HRGN, flag uint32) {
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(lpRect)),
 		uintptr(hrgnUpdate),
-		flag,
+		uintptr(flag),
 	)
-	if ret!=0{
+	if ret != 0 {
 		panic("RedrawWindow fail")
 	}
 	return


### PR DESCRIPTION
was getting compile errors stating that the "flag" variable in user32.go could not be used at a uintptr. It seemed to be a case of "I forgot to convert that one" so I did and that fixed the issue for me.

[Build Env]
OS Name:                   Microsoft Windows 10 Pro
OS Version:                10.0.17134 N/A Build 17134

go version go1.10.2 windows/amd64