### PR TITLE
Changed user32.go's RedrawWindow() to allow compiling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module silverbot01/w32
+
+go 1.22.2

--- a/user32.go
+++ b/user32.go
@@ -1037,10 +1037,11 @@ func RedrawWindow(hWnd HWND, lpRect *RECT, hrgnUpdate HRGN, flag uint32) {
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(lpRect)),
 		uintptr(hrgnUpdate),
-		flag,
+		uintptr(flag),
 	)
-	if ret!=0{
+	if ret != 0 {
 		panic("RedrawWindow fail")
 	}
 	return
 }
+


### PR DESCRIPTION
Currently "flag" passed to procRedrawWindow() isn't allowed by the compiler and must be explicitly passed as a uintptr.

Unsure if an older version of Go's compiler allowed this behavior, but this change will allow Go 1.22.2 to compile projects using this package.